### PR TITLE
Disable no_std tests for now

### DIFF
--- a/.github/workflows/ci-checkin.yaml
+++ b/.github/workflows/ci-checkin.yaml
@@ -19,7 +19,8 @@ jobs:
       matrix:
         flags:
           - ""
-          - "--no-default-features"
+        # TODO: Enable no_std as well.
+        # - "--no-default-features"
     steps:
       - uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable


### PR DESCRIPTION
- Add a workflow for running Cargo
- Disable no_std, for now
